### PR TITLE
Replace unix with not wasm32 in platform-specific dependencies

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ protobuf = "2.0"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustc-serialize = "0.3.22"
 rust-crypto = "0.2"
 

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -11,7 +11,7 @@ cfg-if = "0.1"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sabre-sdk = "0.1"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = "0.1"
 log = "0.4"
 log4rs = "0.8"


### PR DESCRIPTION
This will allow sabre smart contracts to be compiled on more
platforms when not compiling into wasm.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>

To test: Add the wasm32 target rustup target add wasm32-unknown-unknown --toolchain nightly and run both cargo build and cargo +nightly build --target wasm32-unknown-unknown (in the respective directories). Both should pass.