### PR TITLE
Fix error strings for invalid org type on CLI

### DIFF
--- a/cli/src/commands/organization.rs
+++ b/cli/src/commands/organization.rs
@@ -39,15 +39,18 @@ fn run_create_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
     let key = args.value_of("key");
     let url = args.value_of("url").unwrap_or("http://localhost:9009");
 
+    let valid_org_types = "1 - CERTIFYING_BODY \n 2 - STANDARDS_BODY \n 3 - FACTORY";
+
     let organization_type = match args.value_of("org_type").unwrap() {
         "1" => Ok(Organization_Type::CERTIFYING_BODY),
         "2" => Ok(Organization_Type::STANDARDS_BODY),
         "3" => Ok(Organization_Type::FACTORY),
-        "4" => Err(CliError::InvalidInputError(format!("Not implemented"))),
+        "4" => Err(CliError::InvalidInputError(format!(
+            "Organization type 4 is not yet implemented. Valid types are: \n {org_types}",
+            org_types=valid_org_types))),
         other => Err(CliError::UserError(format!(
-            "Invalid organization type: {:?}.
-            It can be 1 for CERTIFYING_BODY or 2 for STANDARDS_BODY ",
-            other
+            "Invalid organization type: {:?}. Valid types are: \n {org_types}",
+            other, org_types=valid_org_types
         ))),
     }?;
 


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT

## Proposed change/fix

When entering an invalid organization type in the CLI (e.g. `creg organization create "Test Factory" "5" "Test User" "012-345-6789" "EN"`), the resulting error message is incomplete.

Currently it reads `Invalid organization type: {:?}. It can be 1 for CERTIFYING_BODY or 2 for STANDARDS_BODY`. This doesn't include the 3rd organization type, `3 for FACTORY`.

## Types of changes

What types of changes is this pull request introducing to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [] I have added necessary documentation (if appropriate)
- [] I have added tests that prove my fix/feature works (if appropriate)