### PR TITLE
Add .npmrc to point at global registry

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.com/


### PR DESCRIPTION
Adding a project-level `.npmrc` to override the default registry - this will prevent enterprise users who have their global `.npmrc` pointed at their company registry from pulling from the wrong registry.

Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Describe your change/fix and tell us why we should accept the it. Linking to the issue(s) is helpful too. If there is no outstanding issue, please create one in correspondence to this PR.

## Types of changes

What types of changes is this pull request introducing to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

- If your global `.npmrc` does not already have a `registry=<registry>` line, run `npm config set registry test.com`
- `cd client/`
- `rm -rf node_modules package-lock.json`
- `npm i`
- `git status` should be empty 
-  If you overwrote your registry in the first step, set it back using `npm config set registry https://registry.npmjs.com/`