### PR TITLE
Add mock app data to genesis batch

### DIFF
--- a/cli/example-genesis.yaml
+++ b/cli/example-genesis.yaml
@@ -1,27 +1,20 @@
-- email: "agent001@example.com"
+- email: "paper-agent@example.com"
   organization:
-      name: "FSC"
+      name: "Paper Standards Body"
       type: StandardsBody
       contact:
-          name: John Q. Standards
+          name: John Q. Paper
           phone_number: 123-456-7890
           language: en
       standards:
-          - name: FSC-C
+          - name: High Qualility Paper Standard
             version: "1.0"
             description: |
-                FSC Chain of Custody Certification
-            link: https://ic.fsc.org/en/document-center/id/80
-            approval_date: 2017/04/01
-          - name: FSC-N
-            version: "1.0"
-            description: |
-                Forest Management Certification
-            link: https://ic.fsc.org/file-download.fsc-and-plantations.a-1723.pdf
-            approval_date: 2017/04/01
-- email: "agent002@example.com"
+                Standard around high quality paper products
+            approval_date: 2019/11/11
+- email: "paper-agent2@example.com"
   organization:
-      name: Rainforest Alliance
+      name: Cardboard Certifying Body
       type: CertifyingBody
       contact:
           name: Jane Forest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
           sawtooth.consensus.algorithm.name=Devmode \
           sawtooth.consensus.algorithm.version=0.1 \
           -o config.batch \
-          && sawadm genesis config-genesis.batch config.batch && \
+          && sawadm genesis config-genesis.batch config.batch /shared_data/creg-genesis.batch && \
         sawtooth-validator -v \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Adds back the mock data in `/shared_data/creg-genesis.batch` to the genesis batch.

## Types of changes

What types of changes is this pull request introducing to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

1. Make sure that you are running the latest 1.2 images.
2. `docker-compose up`
3. Visit http://localhost:8080/#!/agents and you should see a few agents.
