### PR TITLE
Update rest api binary name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       ROCKET_PORT: "9009"
     command: |
       bash -c "
-        cert-registry-rest-api -v --dbhost postgres -C tcp://validator:4004
+        consensource-rest-api -v --dbhost postgres -C tcp://validator:4004
       "
 
   settings-tp:

--- a/rest_api/Cargo.lock
+++ b/rest_api/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cert-registry-rest-api"
+name = "consensource-rest-api"
 version = "0.1.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rest_api/Cargo.toml
+++ b/rest_api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cert-registry-rest-api"
+name = "consensource-rest-api"
 version = "0.1.0"
 
 


### PR DESCRIPTION
## Proposed change/fix

Changing rest-api binary name from `cert-registry-rest-api` to `consensource-rest-api`

## Types of changes

What types of changes is this pull request introducing to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`docker-compose up`